### PR TITLE
fix (LT-3635): replace method returns used product's isins 

### DIFF
--- a/src/MarginTrading.AssetService.Contracts/IAssetsApi.cs
+++ b/src/MarginTrading.AssetService.Contracts/IAssetsApi.cs
@@ -23,10 +23,10 @@ namespace MarginTrading.AssetService.Contracts
         Task<List<string>> GetDiscontinuedIds();
 
         /// <summary>
-        /// Get used isins
+        /// Returns duplicates for a given set of product isins (short, long)
         /// </summary>
-        [Get("/api/assets/used-isins")]
-        Task<List<string>> GetUsedIsins();
+        [Post("/api/assets/duplicated-isins")]
+        Task<List<string>> GetDuplicatedIsins(string[] isins);
 
         /// <summary>
         /// Get the list of assets

--- a/src/MarginTrading.AssetService.SqlRepositories/Repositories/AssetsRepository.cs
+++ b/src/MarginTrading.AssetService.SqlRepositories/Repositories/AssetsRepository.cs
@@ -22,14 +22,18 @@ namespace MarginTrading.AssetService.SqlRepositories.Repositories
             _contextFactory = contextFactory;
         }
 
-        public async Task<IReadOnlyList<string>> GetUsedIsinsAsync()
+        public async Task<IReadOnlyList<string>> GetDuplicatedIsinsAsync(string[] isins)
         {
             using (var context = _contextFactory.CreateDataContext())
             {
-                var filteredQuery = context.Products.Where(x => !x.IsDiscontinued);
-                var longQuery = filteredQuery.Select(x => x.IsinLong);
-                var shortQuery = filteredQuery.Select(x => x.IsinShort);
-                return await longQuery.Union(shortQuery).ToListAsync();
+                var query = context.Products.Where(x => !x.IsDiscontinued);
+                var longQuery = query.Select(x => x.IsinLong).Where(x => isins.Contains(x));
+                var shortQuery = query.Select(x => x.IsinShort).Where(x => isins.Contains(x));
+
+                var duplicates = await longQuery.Concat(shortQuery)
+                    .ToListAsync();
+
+                return duplicates;
             }
         }
 

--- a/src/MarginTrading.AssetService.StorageInterfaces/Repositories/IAssetsRepository.cs
+++ b/src/MarginTrading.AssetService.StorageInterfaces/Repositories/IAssetsRepository.cs
@@ -10,7 +10,7 @@ namespace MarginTrading.AssetService.StorageInterfaces.Repositories
 {
     public interface IAssetsRepository
     {
-        Task<IReadOnlyList<string>> GetUsedIsinsAsync();
+        Task<IReadOnlyList<string>> GetDuplicatedIsinsAsync(string[] isins);
         Task<IReadOnlyList<string>> GetDiscontinuedIdsAsync();
         Task<IReadOnlyList<IAsset>> GetAsync();
         Task<IAsset> GetAsync(string assetId);

--- a/src/MarginTrading.AssetService/Controllers/AssetsController.cs
+++ b/src/MarginTrading.AssetService/Controllers/AssetsController.cs
@@ -66,15 +66,15 @@ namespace MarginTrading.AssetService.Controllers
         }
 
         /// <summary>
-        /// Get used isins
+        /// Returns duplicates for a given product isins (short, long)
         /// </summary>
-        [HttpGet]
-        [Route("used-isins")]
-        public async Task<List<string>> GetUsedIsins()
+        [HttpPost]
+        [Route("duplicated-isins")]
+        public async Task<List<string>> GetDuplicatedIsins([FromBody] string[] isins)
         {
-            var data = await _assetsRepository.GetUsedIsinsAsync();
+            var result = await _assetsRepository.GetDuplicatedIsinsAsync(isins);
 
-            return data.ToList();
+            return result.ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
Replace method returns used product's isins with the one that returns only duplicates for a given set of isins