### PR TITLE
Lt 5024 add asset type cache

### DIFF
--- a/src/MarginTrading.AssetService.Contracts/AssetTypes/AssetTypeCache.cs
+++ b/src/MarginTrading.AssetService.Contracts/AssetTypes/AssetTypeCache.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+namespace MarginTrading.AssetService.Contracts.AssetTypes
+{
+    public class AssetTypeCache : BaseCache<AssetTypeContract>, IAssetTypeCache
+    {
+        private readonly IAssetTypesApi _assetTypesApi;
+        private readonly ILogger<AssetTypeCache> _logger;
+
+        public AssetTypeCache(IAssetTypesApi assetTypesApi, ILogger<AssetTypeCache> logger)
+        {
+            _assetTypesApi = assetTypesApi ?? throw new System.ArgumentNullException(nameof(assetTypesApi));
+            _logger = logger;
+        }
+
+        public override async Task StartAsync()
+        {
+            _logger?.LogInformation("Starting asset types cache ...");
+            
+            await _initializeLock.WaitAsync();
+            try
+            {
+                var response = await _assetTypesApi.GetAssetTypesAsync();
+                _cache = new ConcurrentDictionary<string, AssetTypeContract>(
+                    response.AssetTypes.ToDictionary(x => x.Id, x => x));
+            }
+            finally
+            {
+                _initializeLock.Release();
+                _logger?.LogInformation("Asset types cache has been started. Items: {Count}", _cache.Count);
+            }
+        }
+        
+        protected override string GetKey(AssetTypeContract item) => item.Id;
+    }
+}

--- a/src/MarginTrading.AssetService.Contracts/AssetTypes/AssetTypeCache.cs
+++ b/src/MarginTrading.AssetService.Contracts/AssetTypes/AssetTypeCache.cs
@@ -9,6 +9,10 @@ using Microsoft.Extensions.Logging;
 
 namespace MarginTrading.AssetService.Contracts.AssetTypes
 {
+    /// <summary>
+    /// Asset types cache
+    /// Uses as key - asset type id
+    /// </summary>
     public class AssetTypeCache : BaseCache<AssetTypeContract>, IAssetTypeCache
     {
         private readonly IAssetTypesApi _assetTypesApi;

--- a/src/MarginTrading.AssetService.Contracts/AssetTypes/AssetTypeCache.cs
+++ b/src/MarginTrading.AssetService.Contracts/AssetTypes/AssetTypeCache.cs
@@ -11,7 +11,6 @@ namespace MarginTrading.AssetService.Contracts.AssetTypes
 {
     /// <summary>
     /// Asset types cache
-    /// Uses as key - asset type id
     /// </summary>
     public class AssetTypeCache : BaseCache<AssetTypeContract>, IAssetTypeCache
     {

--- a/src/MarginTrading.AssetService.Contracts/AssetTypes/IAssetTypeCache.cs
+++ b/src/MarginTrading.AssetService.Contracts/AssetTypes/IAssetTypeCache.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2023 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+namespace MarginTrading.AssetService.Contracts.AssetTypes
+{
+    /// <summary>
+    /// Asset type cache interface
+    /// </summary>
+    public interface IAssetTypeCache : IBaseCache<AssetTypeContract>
+    {
+    }
+}

--- a/src/MarginTrading.AssetService.Contracts/BaseCache.cs
+++ b/src/MarginTrading.AssetService.Contracts/BaseCache.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2023 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MarginTrading.AssetService.Contracts
+{
+    public abstract class BaseCache<T> : IBaseCache<T>
+    {
+        protected ConcurrentDictionary<string, T> _cache = new ConcurrentDictionary<string, T>();
+        protected readonly SemaphoreSlim _initializeLock = new SemaphoreSlim(1, 1);
+        
+        public abstract Task StartAsync();
+
+        public virtual bool TryGetValue(string key, out T result) => _cache.TryGetValue(key, out result);
+
+        public virtual void AddOrUpdate(T item)
+        {
+            _cache[GetKey(item)] = item;
+        }
+
+        public virtual bool Remove(T item) => _cache.TryRemove(GetKey(item), out _);
+
+        protected abstract string GetKey(T item);
+    }
+}

--- a/src/MarginTrading.AssetService.Contracts/ClientProfileSettings/ClientProfileSettingsCache.cs
+++ b/src/MarginTrading.AssetService.Contracts/ClientProfileSettings/ClientProfileSettingsCache.cs
@@ -8,6 +8,10 @@ using Microsoft.Extensions.Logging;
 
 namespace MarginTrading.AssetService.Contracts.ClientProfileSettings
 {
+    /// <summary>
+    /// Client profile settings cache
+    /// Uses as key - client profile id + asset type id
+    /// </summary>
     public class ClientProfileSettingsCache : BaseCache<ClientProfileSettingsContract>, IClientProfileSettingsCache
     {
         private readonly IClientProfileSettingsApi _clientProfileSettingsApi;

--- a/src/MarginTrading.AssetService.Contracts/ClientProfileSettings/ClientProfileSettingsCache.cs
+++ b/src/MarginTrading.AssetService.Contracts/ClientProfileSettings/ClientProfileSettingsCache.cs
@@ -1,108 +1,43 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using Common;
+using System.Threading.Tasks;
+
 using Microsoft.Extensions.Logging;
 
 namespace MarginTrading.AssetService.Contracts.ClientProfileSettings
 {
-    public class ClientProfileSettingsCache : IClientProfileSettingsCache
+    public class ClientProfileSettingsCache : BaseCache<ClientProfileSettingsContract>, IClientProfileSettingsCache
     {
         private readonly IClientProfileSettingsApi _clientProfileSettingsApi;
         private readonly ILogger<ClientProfileSettingsCache> _logger;
 
-        private Dictionary<string, ClientProfileSettingsContract> _cache =
-            new Dictionary<string, ClientProfileSettingsContract>();
-
-        private readonly ReaderWriterLockSlim _lockSlim = new ReaderWriterLockSlim();
-
         public ClientProfileSettingsCache(IClientProfileSettingsApi clientProfileSettingsApi, 
             ILogger<ClientProfileSettingsCache> logger)
         {
-            _clientProfileSettingsApi = clientProfileSettingsApi;
+            _clientProfileSettingsApi = clientProfileSettingsApi ??
+                                        throw new ArgumentNullException(nameof(clientProfileSettingsApi));
             _logger = logger;
         }
 
-        public void Start()
+        public override async Task StartAsync()
         {
             _logger?.LogInformation("Starting client profile settings cache ...");
-            
-            _lockSlim.EnterWriteLock();
+
+            await _initializeLock.WaitAsync();
             try
             {
-                var response = _clientProfileSettingsApi
-                    .GetClientProfileSettingsByRegulationAsync()
-                    .GetAwaiter()
-                    .GetResult();
+                var response = await _clientProfileSettingsApi
+                    .GetClientProfileSettingsByRegulationAsync();
 
-                _cache = response.ClientProfileSettings.ToDictionary(GetKey, x => x);
-                
+                _cache = new ConcurrentDictionary<string, ClientProfileSettingsContract>(
+                    response.ClientProfileSettings.ToDictionary(GetKey, x => x));
+            }
+            finally
+            {
+                _initializeLock.Release();
                 _logger?.LogInformation("Client profile settings cache has been started. Items: {Count}", _cache.Count);
-            }
-            finally
-            {
-                _lockSlim.ExitWriteLock();
-            }
-        }
-
-        public void AddOrUpdate(ClientProfileSettingsContract clientProfileSettings)
-        {
-            _lockSlim.EnterWriteLock();
-            try
-            {
-                _cache[GetKey(clientProfileSettings)] = clientProfileSettings;
-
-                _logger?.LogDebug(
-                    "New entry has been added into client profile settings cache. Items: {count}. Entry: {clientProfileSettings}.", 
-                    _cache.Count,
-                    clientProfileSettings.ToJson());
-            }
-            finally
-            {
-                _lockSlim.ExitWriteLock();
-            }
-        }
-
-        public void Remove(ClientProfileSettingsContract clientProfileSettings)
-        {
-            _lockSlim.EnterWriteLock();
-            try
-            {
-                _cache.Remove(GetKey(clientProfileSettings));
-
-                _logger?.LogDebug(
-                    "One entry has been removed from client profile settings cache. Items: {count}. Entry: {clientProfileSettings}",
-                    _cache.Count,
-                    clientProfileSettings.ToJson());
-            }
-            finally
-            {
-                _lockSlim.ExitWriteLock();
-            }
-        }
-
-        public ClientProfileSettingsContract GetByIds(string profileId, string assetType)
-        {
-            _cache.TryGetValue(GetKey(profileId, assetType), out var result);
-
-            if (result == null)
-                throw new ArgumentOutOfRangeException(nameof(profileId),
-                    $"Client profile settings not found for profile [{profileId}] and asset type [{assetType}]");
-
-            return result;
-        }
-
-        public bool TryGetValue(string profileId, string assetType, out ClientProfileSettingsContract result)
-        {
-            _lockSlim.EnterReadLock();
-            try
-            {
-                return _cache.TryGetValue(GetKey(profileId, assetType), out result);
-            }
-            finally
-            {
-                _lockSlim.ExitReadLock();
             }
         }
 
@@ -111,25 +46,17 @@ namespace MarginTrading.AssetService.Contracts.ClientProfileSettings
             if (string.IsNullOrEmpty(assetType))
                 throw new ArgumentNullException(nameof(assetType));
 
-            _lockSlim.EnterReadLock();
-            try
+            var result = _cache.Values.Where(Filter).ToList();
+            if (!result.Any())
             {
-                var result = _cache.Values.Where(Filter).ToList();
-                if (!result.Any())
-                {
-                    _logger?.LogDebug(
-                        "Couldn't find client profile settings cache entries for assetType={assetType} with availableOnly={availableOnly}. Items: {count}",
-                        assetType,
-                        availableOnly,
-                        _cache.Count);
-                }
+                _logger?.LogDebug(
+                    "Couldn't find client profile settings cache entries for assetType={assetType} with availableOnly={availableOnly}. Items: {count}",
+                    assetType,
+                    availableOnly,
+                    _cache.Count);
+            }
 
-                return result;
-            }
-            finally
-            {
-                _lockSlim.ExitReadLock();
-            }
+            return result;
 
             bool Filter(ClientProfileSettingsContract src)
             {
@@ -137,14 +64,9 @@ namespace MarginTrading.AssetService.Contracts.ClientProfileSettings
             }
         }
 
-        private string GetKey(ClientProfileSettingsContract clientProfileSettings)
+        protected override string GetKey(ClientProfileSettingsContract clientProfileSettings)
         {
-            return GetKey(clientProfileSettings.ClientProfileId, clientProfileSettings.AssetTypeId);
-        }
-
-        private string GetKey(string clientProfileId, string assetType)
-        {
-            return $"{clientProfileId}_{assetType}";
+            return $"{clientProfileSettings.ClientProfileId}_{clientProfileSettings.AssetTypeId}";
         }
     }
 }

--- a/src/MarginTrading.AssetService.Contracts/ClientProfileSettings/ClientProfileSettingsCache.cs
+++ b/src/MarginTrading.AssetService.Contracts/ClientProfileSettings/ClientProfileSettingsCache.cs
@@ -10,7 +10,6 @@ namespace MarginTrading.AssetService.Contracts.ClientProfileSettings
 {
     /// <summary>
     /// Client profile settings cache
-    /// Uses as key - client profile id + asset type id
     /// </summary>
     public class ClientProfileSettingsCache : BaseCache<ClientProfileSettingsContract>, IClientProfileSettingsCache
     {
@@ -45,6 +44,9 @@ namespace MarginTrading.AssetService.Contracts.ClientProfileSettings
             }
         }
 
+        public bool TryGetValue(string clientProfileId, string assetTypeId, out ClientProfileSettingsContract result) =>
+            TryGetValue(GetKey(clientProfileId, assetTypeId), out result);
+
         public IReadOnlyList<ClientProfileSettingsContract> GetByAssetType(string assetType, bool availableOnly = false)
         {
             if (string.IsNullOrEmpty(assetType))
@@ -68,9 +70,9 @@ namespace MarginTrading.AssetService.Contracts.ClientProfileSettings
             }
         }
 
-        protected override string GetKey(ClientProfileSettingsContract clientProfileSettings)
-        {
-            return $"{clientProfileSettings.ClientProfileId}_{clientProfileSettings.AssetTypeId}";
-        }
+        protected override string GetKey(ClientProfileSettingsContract clientProfileSettings) =>
+            GetKey(clientProfileSettings.ClientProfileId, clientProfileSettings.AssetTypeId);
+
+        private static string GetKey(string clientProfileId, string assetTypeId) => $"{clientProfileId}_{assetTypeId}";
     }
 }

--- a/src/MarginTrading.AssetService.Contracts/ClientProfileSettings/IClientProfileSettingsCache.cs
+++ b/src/MarginTrading.AssetService.Contracts/ClientProfileSettings/IClientProfileSettingsCache.cs
@@ -4,6 +4,7 @@ namespace MarginTrading.AssetService.Contracts.ClientProfileSettings
 {
     public interface IClientProfileSettingsCache : IBaseCache<ClientProfileSettingsContract>
     {
+        bool TryGetValue(string clientProfileId, string assetTypeId, out ClientProfileSettingsContract result);
         IReadOnlyList<ClientProfileSettingsContract> GetByAssetType(string assetType, bool availableOnly = false);
     }
 }

--- a/src/MarginTrading.AssetService.Contracts/ClientProfileSettings/IClientProfileSettingsCache.cs
+++ b/src/MarginTrading.AssetService.Contracts/ClientProfileSettings/IClientProfileSettingsCache.cs
@@ -1,21 +1,9 @@
-using System;
 using System.Collections.Generic;
 
 namespace MarginTrading.AssetService.Contracts.ClientProfileSettings
 {
-    public interface IClientProfileSettingsCache
+    public interface IClientProfileSettingsCache : IBaseCache<ClientProfileSettingsContract>
     {
-        void Start();
-        
-        void AddOrUpdate(ClientProfileSettingsContract clientProfileSettings);
-        
-        void Remove(ClientProfileSettingsContract clientProfileSettings);
-        
-        [Obsolete("Will be removed in future releases. Please use TryGetValue instead.")]
-        ClientProfileSettingsContract GetByIds(string profileId, string assetType);
-
-        bool TryGetValue(string profileId, string assetType, out ClientProfileSettingsContract result);
-
         IReadOnlyList<ClientProfileSettingsContract> GetByAssetType(string assetType, bool availableOnly = false);
     }
 }

--- a/src/MarginTrading.AssetService.Contracts/DependencyInjectionExtensions.cs
+++ b/src/MarginTrading.AssetService.Contracts/DependencyInjectionExtensions.cs
@@ -1,3 +1,4 @@
+using MarginTrading.AssetService.Contracts.AssetTypes;
 using MarginTrading.AssetService.Contracts.ClientProfileSettings;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -13,6 +14,16 @@ namespace MarginTrading.AssetService.Contracts
         public static void AddClientProfileSettingsCache(this IServiceCollection services)
         {
             services.AddSingleton<IClientProfileSettingsCache, ClientProfileSettingsCache>();
+        }
+        
+        /// <summary>
+        /// Registers <see cref="IAssetTypeCache"/> in the .NET Core DI Container.
+        /// Requires <see cref="IAssetTypesApi"/> to be registered.
+        /// </summary>
+        /// <param name="services"></param>
+        public static void AddAssetTypesCache(this IServiceCollection services)
+        {
+            services.AddSingleton<IAssetTypeCache, AssetTypeCache>();
         }
     }
 }

--- a/src/MarginTrading.AssetService.Contracts/IBaseCache.cs
+++ b/src/MarginTrading.AssetService.Contracts/IBaseCache.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2023 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace MarginTrading.AssetService.Contracts
+{
+    /// <summary>
+    /// Base cache interface
+    /// </summary>
+    public interface IBaseCache<T>
+    {
+        /// <summary>
+        /// Initialize cache
+        /// </summary>
+        Task StartAsync();
+
+        /// <summary>
+        /// Get item by key
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="result"></param>
+        /// <returns>
+        /// True if item was found
+        /// </returns>
+        bool TryGetValue(string key, out T result);
+        
+        /// <summary>
+        /// Adds or updates item in cache
+        /// </summary>
+        void AddOrUpdate(T item);
+        
+        /// <summary>
+        /// Removes item from cache
+        /// </summary>
+        /// <returns>
+        /// True if item was removed
+        /// </returns>
+        bool Remove(T item);
+    }
+}

--- a/tests/MarginTrading.AssetService.Tests/Contracts/TickFormulaExtensionsTests.cs
+++ b/tests/MarginTrading.AssetService.Tests/Contracts/TickFormulaExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 
 using MarginTrading.AssetService.Contracts.Extensions;
 using MarginTrading.AssetService.Contracts.LegacyAsset;
@@ -25,7 +26,7 @@ namespace MarginTrading.AssetService.Tests.Contracts
         public void Test_Decimal_GetPrecision(string valueAsString, uint expectedPrecision)
         {
             // Act
-            var value = decimal.Parse(valueAsString);
+            var value = decimal.Parse(valueAsString, CultureInfo.InvariantCulture);
             var actualPrecision = value.GetPrecision();
 
             // Assert


### PR DESCRIPTION
This PR introduces several changes:

- adds basic implementation for cache, can be considered to move to separate library. Basic implementation uses `ConcurrentDictionary` instead of plain `Dictionary` + `ReadWriteSlimLock`.
- updates ClientProfileSettingsCache to use BaseCache
- adds AssetType cache based on BaseCache
- removes obsolete methods from ClientProfileSettingsCache