### PR TITLE
LT-4961 - Verbose level logging

### DIFF
--- a/src/MarginTrading.AssetService/appsettings.Serilog.json
+++ b/src/MarginTrading.AssetService/appsettings.Serilog.json
@@ -2,7 +2,7 @@
   "serilog": {
     "Using": [ "Serilog.Sinks.File", "Serilog.Sinks.Async", "Serilog.Sinks.Elasticsearch" ],
     "minimumLevel": {
-      "default": "Debug"
+      "default": "Verbose"
     },
     "writeTo": [
       {


### PR DESCRIPTION
I was not able to reproduce this isssue locally. Try to look for memory leaks, but memory seems to be fine locally and in k8s. So my last idea is to set minimum level of logging to Verbose and wait is this issue occur again. 